### PR TITLE
fix attempt

### DIFF
--- a/packages/db/src/__generated__/wasm-worker-loader.js
+++ b/packages/db/src/__generated__/wasm-worker-loader.js
@@ -1,1 +1,1 @@
-export default (await import('./query_engine_bg.wasm')).default
+export default (await import('./query_engine_bg.wasm?init')).default

--- a/packages/db/src/prisma.ts
+++ b/packages/db/src/prisma.ts
@@ -1,6 +1,6 @@
 import { Pool } from './pg';
 import { PrismaPg } from '@prisma/adapter-pg';
-import { PrismaClient } from './__generated__/edge';
+import { PrismaClient } from './__generated__';
 
 export const prisma = (
   connectionString: string,


### PR DESCRIPTION
No `/edge` needed in import. Then shows the real problem:
```
x Build failed in 51ms
Error: [vite:wasm-fallback] Could not load /workspace/vite-hyper/packages/db/src/__generated__/query_engine_bg.wasm (imported by ../../packages/db/src/__generated__/wasm-worker-loader.js): "ESM integration proposal for Wasm" is not supported currently. Use vite-plugin-wasm or other community plugins to handle this. Alternatively, you can use `.wasm?init` or `.wasm?url`. See https://vitejs.dev/guide/features.html#webassembly for more details.
    at Object.load (file:///workspace/vite-hyper/node_modules/.pnpm/vite@5.2.8/node_modules/vite/dist/node/chunks/dep-whKeNLxG.js:49345:19)
    at Object.handler (file:///workspace/vite-hyper/node_modules/.pnpm/vite@5.2.8/node_modules/vite/dist/node/chunks/dep-whKeNLxG.js:67671:19)
    at file:///workspace/vite-hyper/node_modules/.pnpm/rollup@4.14.1/node_modules/rollup/dist/es/shared/node-entry.js:19597:40
    at async PluginDriver.hookFirstAndGetPlugin (file:///workspace/vite-hyper/node_modules/.pnpm/rollup@4.14.1/node_modules/rollup/dist/es/shared/node-entry.js:19497:28)
    at async file:///workspace/vite-hyper/node_modules/.pnpm/rollup@4.14.1/node_modules/rollup/dist/es/shared/node-entry.js:18668:33
    at async Queue.work (file:///workspace/vite-hyper/node_modules/.pnpm/rollup@4.14.1/node_modules/rollup/dist/es/shared/node-entry.js:19707:32) {
  code: 'PLUGIN_ERROR',
  plugin: 'vite:wasm-fallback',
  hook: 'load',
  watchFiles: [
    '/workspace/vite-hyper/apps/builder/app/entry.server.tsx',
    '/workspace/vite-hyper/apps/builder/app/root.tsx',
    '/workspace/vite-hyper/apps/builder/app/routes/_index.tsx',
    '/workspace/vite-hyper/apps/builder/package.json',
    '/workspace/vite-hyper/packages/db/package.json',
    '/workspace/vite-hyper/packages/db/src/prisma.ts',
    '/workspace/vite-hyper/packages/db/src/__generated__/package.json',
    '/workspace/vite-hyper/packages/db/src/pg.ts',
    '/workspace/vite-hyper/node_modules/.pnpm/@prisma+adapter-pg@5.12.1_pg@8.11.5/node_modules/@prisma/adapter-pg/dist/index.mjs',
    '/workspace/vite-hyper/packages/db/src/__generated__/wasm.js',
    '/workspace/vite-hyper/node_modules/.pnpm/postgres-array@3.0.2/node_modules/postgres-array/index.js',
    '/workspace/vite-hyper/node_modules/.pnpm/pg@8.11.5/node_modules/pg/lib/index.js',
    '/workspace/vite-hyper/node_modules/.pnpm/@prisma+driver-adapter-utils@5.12.1/node_modules/@prisma/driver-adapter-utils/dist/index.mjs',
    '/workspace/vite-hyper/packages/db/src/__generated__/wasm-worker-loader.js'
  ]
}
 ELIFECYCLE  Command failed with exit code 1.
```