### PR TITLE
Add fixes

### DIFF
--- a/apps/builder/app/routes/_index.tsx
+++ b/apps/builder/app/routes/_index.tsx
@@ -32,7 +32,10 @@ export async function loader({ context }: LoaderFunctionArgs) {
     context.cloudflare.env.DEV_MODE_DATABASE_URL;
   console.log('connStr:', connStr);
 
-  const user = await prisma(connStr, context.cloudflare.ctx.waitUntil); //.user.findFirst();
+  const user = await prisma(
+    connStr,
+    context.cloudflare.ctx.waitUntil
+  ).user.findFirst();
 
   console.log('END', user);
 

--- a/apps/builder/package.json
+++ b/apps/builder/package.json
@@ -40,6 +40,7 @@
     "node-fetch": "^3.3.2",
     "typescript": "^5.1.6",
     "vite": "^5.1.0",
+    "vite-plugin-wasm": "^3.3.0",
     "vite-tsconfig-paths": "^4.2.1",
     "wrangler": "^3.48.0"
   },

--- a/apps/builder/vite.config.ts
+++ b/apps/builder/vite.config.ts
@@ -70,8 +70,6 @@ export default defineConfig(({ mode }) => ({
       ),
 
       util: 'node:util',
-      '.prisma/client/edge':
-        '../../node_modules/.pnpm/@prisma+client@5.12.1_prisma@5.12.1/node_modules/@prisma/client/edge.js',
     },
   },
 }));

--- a/apps/builder/vite.config.ts
+++ b/apps/builder/vite.config.ts
@@ -5,17 +5,32 @@ import {
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { fileURLToPath } from 'url';
+import commonjs from '@rollup/plugin-commonjs';
+import wasm from 'vite-plugin-wasm';
 
 export default defineConfig(({ mode }) => ({
   ssr: {},
-  plugins: [remixCloudflareDevProxy(), remix(), tsconfigPaths()],
+  plugins: [
+    remixCloudflareDevProxy(),
+    remix(),
+    tsconfigPaths(),
+
+    commonjs({
+      include: ['**/__generated__/**'],
+    }),
+    wasm(),
+  ],
   define: {
     'process.env.NODE_ENV': JSON.stringify(mode),
+  },
 
-    // process: JSON.stringify({ env: {} }),
+  optimizeDeps: {
+    //include: ['esm-dep > cjs-dep'],
+    // include: ['@prisma/client', 'pg', '**/./__generated__/**'],
   },
 
   build: {
+    target: 'esnext',
     rollupOptions: {
       external: ['cloudflare:sockets'],
     },
@@ -55,8 +70,8 @@ export default defineConfig(({ mode }) => ({
       ),
 
       util: 'node:util',
-      // '.prisma/client/edge':
-      //  '../../node_modules/.pnpm/@prisma+client@5.12.1_prisma@5.12.1/node_modules/@prisma/client/edge.js',
+      '.prisma/client/edge':
+        '../../node_modules/.pnpm/@prisma+client@5.12.1_prisma@5.12.1/node_modules/@prisma/client/edge.js',
     },
   },
 }));

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "packageManager": "pnpm@8.15.6",
   "name": "CTAPKOB",
   "version": "1.0.0",
   "description": "",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -19,5 +19,8 @@
     "@types/pg": "^8.11.5",
     "pg": "^8.11.5",
     "prisma": "^5.12.1"
+  },
+  "devDependencies": {
+    "esbuild": "^0.20.2"
   }
 }

--- a/packages/db/src/prisma.ts
+++ b/packages/db/src/prisma.ts
@@ -1,6 +1,8 @@
 import { Pool } from './pg';
 import { PrismaPg } from '@prisma/adapter-pg';
-import { PrismaClient } from './__generated__/edge';
+import { PrismaClient } from './__generated__';
+
+globalThis.URL = URL;
 
 export const prisma = (
   connectionString: string,
@@ -11,5 +13,5 @@ export const prisma = (
   const adapter = new PrismaPg(pool);
   const prisma = new PrismaClient({ adapter });
 
-  return {};
+  return prisma;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       vite:
         specifier: ^5.1.0
         version: 5.2.8
+      vite-plugin-wasm:
+        specifier: ^3.3.0
+        version: 3.3.0(vite@5.2.8)
       vite-tsconfig-paths:
         specifier: ^4.2.1
         version: 4.3.2(typescript@5.4.4)(vite@5.2.8)
@@ -171,6 +174,10 @@ importers:
       prisma:
         specifier: ^5.12.1
         version: 5.12.1
+    devDependencies:
+      esbuild:
+        specifier: ^0.20.2
+        version: 0.20.2
 
 packages:
 
@@ -6963,6 +6970,14 @@ packages:
       - sugarss
       - supports-color
       - terser
+    dev: true
+
+  /vite-plugin-wasm@3.3.0(vite@5.2.8):
+    resolution: {integrity: sha512-tVhz6w+W9MVsOCHzxo6SSMSswCeIw4HTrXEi6qL3IRzATl83jl09JVO1djBqPSwfjgnpVHNLYcaMbaDX5WB/pg==}
+    peerDependencies:
+      vite: ^2 || ^3 || ^4 || ^5
+    dependencies:
+      vite: 5.2.8
     dev: true
 
   /vite-tsconfig-paths@4.3.2(typescript@5.4.4)(vite@5.2.8):


### PR DESCRIPTION
This fixes start and build
And now it fails at runtime with
```
✘ [ERROR] CompileError: WebAssembly.instantiate(): Wasm code generation disallowed by embedder

      at __vite__initWasm
  (file:///Users/ice/webstudio-is/CTAPKOB/apps/builder/build/server/assets/query_engine_bg-BBipm4y2.js:34:36)
      at ../build/server/assets/query_engine_bg-BBipm4y2.js
  (file:///Users/ice/webstudio-is/CTAPKOB/apps/builder/build/server/assets/query_engine_bg-BBipm4y2.js:60:34)
      at __init
  (file:///Users/ice/webstudio-is/CTAPKOB/apps/builder/.wrangler/tmp/dev-5k7Koq/dbp398dwduc.js:34:59)
```


